### PR TITLE
:hammer: Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,56 @@
-SHELL := /bin/bash
+SPACE := $(subst , ,)
+PACK = $(subst $(SPACE),,$(1))
+CMD_NOT_FOUND = $(error $(call PACK, $(1)) is required for this rule)
 
-GREEN := \033[32m
-RESET := \033[39m
-ARROW := \033[1m\033[31m>$(GREEN)>\033[33m>$(RESET)
+define check_cmd
+    $(if $(shell command -v $(1)),, $(call CMD_NOT_FOUND, $(1)))
+endef
 
-run:
-	@ echo -e "${ARROW} Running project..."
-	@ npm run dev
+$(call check_cmd, echo)
+$(call check_cmd, tput)
 
-	@ echo -e "[${GREEN}OK${RESET}] Done"
+ifneq ($(shell tput colors),0)
+    GREEN := \e[32m
+    RED := \e[31m
+    YELLOW := \e[33m
+    RESET := \e[39m
+endif
+
+ARROW := $(RED)>$(GREEN)>$(YELLOW)>$(RESET)
+OK := [$(GREEN)OK$(RESET)]
+
+DEPS_FOLDER := node_modules
+DIST := dist
+
+all: run
+
+$(DEPS_FOLDER):
+	$(call check_cmd, npm)
+	@ npm install
+
+run: $(DEPS_FOLDER)
+	$(call check_cmd, npm)
+	@ echo -e "$(ARROW) Running project..."
+	@ npm run dev $(NPM_FLAGS)
+	@ echo -e "$(OK) Done"
 
 .PHONY: run
+
+host: NPM_FLAGS := -- --host
+host: run
+
+.PHONY: host
+
+clean:
+	@ $(RM) -r $(DIST)
+	@ echo -e "$(OK) Removed build"
+
+fclean: clean
+	@ $(RM) -r $(DEPS_FOLDER)
+	@ echo -e "$(OK) Removed node modules"
+
+.PHONY: clean fclean
+
+re: fclean all
+
+.PHONY: re

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,10 @@ SPACE := $(subst , ,)
 PACK = $(subst $(SPACE),,$(1))
 CMD_NOT_FOUND = $(error $(call PACK, $(1)) is required for this rule)
 
-define check_cmd
-    $(if $(shell command -v $(1)),, $(call CMD_NOT_FOUND, $(1)))
-endef
+CHECK_CMD = $(if $(shell command -v $(1)),, $(call CMD_NOT_FOUND, $(1)))
 
-$(call check_cmd, echo)
-$(call check_cmd, tput)
+$(call CHECK_CMD, echo)
+$(call CHECK_CMD, tput)
 
 ifneq ($(shell tput colors),0)
     GREEN := \e[32m
@@ -25,11 +23,11 @@ DIST := dist
 all: run
 
 $(DEPS_FOLDER):
-	$(call check_cmd, npm)
+	$(call CHECK_CMD, npm)
 	@ npm install
 
 run: $(DEPS_FOLDER)
-	$(call check_cmd, npm)
+	$(call CHECK_CMD, npm)
 	@ echo -e "$(ARROW) Running project..."
 	@ npm run dev $(NPM_FLAGS)
 	@ echo -e "$(OK) Done"

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ run: $(DEPS_FOLDER)
 host: NPM_FLAGS := -- --host
 host: run
 
+build: $(DEPS_FOLDER) clean
+	$(call CHECK_CMD, npm)
+	@ npm run build
+
 .PHONY: host
 
 clean:


### PR DESCRIPTION
Hi, i wanted to try the project, but i had a issue with the makefile erorring in a quite unfriendly manner.

```
/bin/bash: line 1: npm: command not found
make: *** [Makefile:9: run] Error 127
```

So i added a command checker, that can be call in specific rules:
```
Makefile:29: *** npm is required for this rule.  Stop.
```

Here is the syntax:
```make
$(call check_cmd, npm)
```
Is can also be called outside any rule for a global check.

I also added a `host` rlue that calls `vite` with the `--host` flags to expose the app on the network.

Finally I added a `clean`, `fclean` & `re` utility rules.